### PR TITLE
refactor: response headers part

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	rk "github.com/dannypsnl/rocket"
+	"github.com/dannypsnl/rocket/response"
 )
 
 type User struct {
@@ -15,7 +16,7 @@ var (
 	hello = rk.Get("/:name/age/:age", func(user *User) string {
 		return fmt.Sprintf("Hello %s, your age is %d\n", user.Name, user.Age)
 	})
-	homePage = rk.Get("/", func() rk.Html {
+	homePage = rk.Get("/", func() response.Html {
 		return `<h1>Title</h1>`
 	})
 )

--- a/handler.go
+++ b/handler.go
@@ -37,12 +37,12 @@ func (h *handler) Handle(rs []string, w http.ResponseWriter, r *http.Request) {
 	switch resp.(type) {
 	case *response.Response:
 		res := resp.(*response.Response)
-		w.Header().Set("Content-Type", contentTypeOf(res.Body))
 		res.SetCookie(w)
+		w.Header().Set("Content-Type", response.ContentTypeOf(res.Body))
 		res.SetHeaders(w)
 		fmt.Fprint(w, res.Body)
 	default:
-		w.Header().Set("Content-Type", contentTypeOf(resp))
+		w.Header().Set("Content-Type", response.ContentTypeOf(resp))
 		fmt.Fprint(w, resp)
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -38,10 +38,8 @@ func (h *handler) Handle(rs []string, w http.ResponseWriter, r *http.Request) {
 	case *response.Response:
 		res := resp.(*response.Response)
 		w.Header().Set("Content-Type", contentTypeOf(res.Body))
-		for k, v := range res.Headers {
-			w.Header().Set(k, v)
-		}
 		res.SetCookie(w)
+		res.SetHeaders(w)
 		fmt.Fprint(w, res.Body)
 	default:
 		w.Header().Set("Content-Type", contentTypeOf(resp))

--- a/helper.go
+++ b/helper.go
@@ -17,19 +17,6 @@ func verifyBase(route string) bool {
 	return true
 }
 
-func contentTypeOf(response interface{}) string {
-	switch response.(type) {
-	case Html:
-		return "text/html"
-	case Json:
-		return "application/json"
-	case string:
-		return "text/plain"
-	default:
-		return "text/plain"
-	}
-}
-
 func parseParameter(v reflect.Value, param string) reflect.Value {
 	switch v.Kind() {
 	case reflect.Bool:

--- a/helper.go
+++ b/helper.go
@@ -17,6 +17,19 @@ func verifyBase(route string) bool {
 	return true
 }
 
+func contentTypeOf(response interface{}) string {
+	switch response.(type) {
+	case Html:
+		return "text/html"
+	case Json:
+		return "application/json"
+	case string:
+		return "text/plain"
+	default:
+		return "text/plain"
+	}
+}
+
 func parseParameter(v reflect.Value, param string) reflect.Value {
 	switch v.Kind() {
 	case reflect.Bool:

--- a/response/content_type_test.go
+++ b/response/content_type_test.go
@@ -1,4 +1,4 @@
-package rocket
+package response
 
 import (
 	"github.com/dannypsnl/assert"
@@ -23,6 +23,6 @@ func TestSetupHeaderContentType(t *testing.T) {
 func testContentType(t *testing.T, response interface{}, expectedContentType string) {
 	t.Helper()
 	assert := assert.NewTester(t)
-	actualContentType := contentTypeOf(response)
+	actualContentType := ContentTypeOf(response)
 	assert.Eq(actualContentType, expectedContentType)
 }

--- a/response/response.go
+++ b/response/response.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Response struct {
-	Headers map[string]string
+	headers map[string]string
 	Body    interface{}
 	cookies []*http.Cookie
 }
@@ -16,7 +16,7 @@ type Headers map[string]string
 
 func New(body interface{}) *Response {
 	return &Response{
-		Headers: make(map[string]string),
+		headers: make(map[string]string),
 		Body:    body,
 		cookies: make([]*http.Cookie, 0),
 	}
@@ -24,7 +24,7 @@ func New(body interface{}) *Response {
 
 func (res *Response) WithHeaders(headers Headers) *Response {
 	for k, v := range headers {
-		res.Headers[k] = v
+		res.headers[k] = v
 	}
 	return res
 }
@@ -39,5 +39,11 @@ func (res *Response) Cookies(cs ...*cookie.Cookie) *Response {
 func (res *Response) SetCookie(w http.ResponseWriter) {
 	for _, c := range res.cookies {
 		http.SetCookie(w, c)
+	}
+}
+
+func (res *Response) SetHeaders(w http.ResponseWriter) {
+	for k, v := range res.headers {
+		w.Header().Set(k, v)
 	}
 }

--- a/response/response_types.go
+++ b/response/response_types.go
@@ -1,0 +1,21 @@
+package response
+
+func ContentTypeOf(response interface{}) string {
+	switch response.(type) {
+	case Html:
+		return "text/html"
+	case Json:
+		return "application/json"
+	case string:
+		return "text/plain"
+	default:
+		return "text/plain"
+	}
+}
+
+// Html is a mark for text is HTML
+// return "Content-Type": "text/html"
+type Html string
+
+// Json will return "Content-Type": "application/json"
+type Json string

--- a/response_types.go
+++ b/response_types.go
@@ -1,8 +1,0 @@
-package rocket
-
-// Html is a mark for text is HTML
-// return "Content-Type": "text/html"
-type Html string
-
-// Json will return "Content-Type": "application/json"
-type Json string

--- a/rocket.go
+++ b/rocket.go
@@ -85,16 +85,3 @@ func (rk *Rocket) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, response)
 
 }
-
-func contentTypeOf(response interface{}) string {
-	switch response.(type) {
-	case Html:
-		return "text/html"
-	case Json:
-		return "application/json"
-	case string:
-		return "text/plain"
-	default:
-		return "text/plain"
-	}
-}

--- a/server_test.go
+++ b/server_test.go
@@ -32,7 +32,7 @@ type Files struct {
 }
 
 var (
-	homePage = rocket.Get("/", func() rocket.Html {
+	homePage = rocket.Get("/", func() response.Html {
 		return `
 		<h1>Title</h1>
 		<p>Hello, World</p>
@@ -41,7 +41,7 @@ var (
 	staticFiles = rocket.Get("/static/*filename", func(fs *Files) string {
 		return fs.FileName
 	})
-	forPost = rocket.Post("/post", func(f *ForPost) rocket.Json {
+	forPost = rocket.Post("/post", func(f *ForPost) response.Json {
 		return `{"value": "response"}`
 	})
 	forPatch = rocket.Patch("/patch", func(f *ForPatch) string {
@@ -75,7 +75,7 @@ var (
 		)
 	})
 	customResponseForHeader = rocket.Get("/", func() *response.Response {
-		body := rocket.Json(`{"msg": "welcome"}`)
+		body := response.Json(`{"msg": "welcome"}`)
 		return response.New(body).WithHeaders(
 			response.Headers{
 				"Access-Control-Allow-Origin": "*",
@@ -99,7 +99,7 @@ func TestServer(t *testing.T) {
 		Mount("/users", user).
 		Mount("/test", query, endWithSlash, forPatch, forPost, handleCookies, handlerHeaders, context, createCookie, deleteCookie).
 		Mount("/custom-response-header", customResponseForHeader).
-		Default(func() rocket.Html {
+		Default(func() response.Html {
 			return "<h1>Page Not Found</h1>"
 		})
 	ts := httptest.NewServer(rk)


### PR DESCRIPTION
- move content-type helper into helper file
- private the headers contains by response.Response
- create SetHeaders method for Response
    rewrite handler part to fit