### PR TITLE
(#144) fix: rocket didn't update request by return of OnRequest

### DIFF
--- a/rocket.go
+++ b/rocket.go
@@ -67,7 +67,7 @@ func (rk *Rocket) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqURL := convertToList(r.URL.Path)
 
 	for _, f := range rk.listOfFairing {
-		f.OnRequest(r)
+		r = f.OnRequest(r)
 	}
 
 	// get response


### PR DESCRIPTION
In my view, I think we should leave more power for users, so this fix can even make users create a new request to replace the old one.

p.s. We don't have to update __CHANGELOG__ since __fairing__ haven't released.